### PR TITLE
fix: replace `repo_name` with `project_slug`, and add parent directory to import path.

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -70,7 +70,7 @@ def load_template(source_dir, target_dir):
 
 def main():
     target_directory = Path().cwd()
-    copy_package_files("bg-cookiecutter-overleaf.templates", cookiecutter.template, target_directory)
+    copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.template }}", target_directory)
     clone_headers(target_directory)
     template_directory = Path().cwd() / cookiecutter.template
     load_template(template_directory, target_directory)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -72,8 +72,8 @@ def main():
     target_directory = Path().cwd()
     copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.template }}", target_directory)
     clone_headers(target_directory)
-    template_directory = Path().cwd() / cookiecutter.template
-    load_template(template_directory, target_directory)
+    # template_directory = Path().cwd() / cookiecutter.template
+    # load_template(template_directory, target_directory)
 
 
 if __name__ == "__main__":

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,9 +3,8 @@ import shutil
 import subprocess
 import tempfile
 from importlib.resources import as_file, files
+import sys
 
-
-from envs import cookiecutter
 
 from importlib.resources import files, as_file
 from pathlib import Path
@@ -69,6 +68,7 @@ def load_template(source_dir, target_dir):
 
 
 def main():
+    sys.path.append(str(Path().cwd().parent))
     target_directory = Path().cwd()
     copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.template }}", target_directory)
     clone_headers(target_directory)

--- a/templates/iucr/manuscript.tex
+++ b/templates/iucr/manuscript.tex
@@ -153,7 +153,7 @@ text text text text text text text.
 
 \end{enumerate}
 
-\bibliography{bg-pdf-standards, billinge-group-bib, {{ cookiecutter.repo_name }}.bib, hand-coded.bib}
+\bibliography{bg-pdf-standards, billinge-group-bib, {{ cookiecutter.project_slug }}.bib, hand-coded.bib}
 \subfile{supplementary-information}
 \end{document}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -8,6 +8,6 @@ from https://github.com/Billingegroup/latex-headers.
 
 ## Bibliography Setup
 Please export the most up-to-date .bib files from Zotero:
-`bg-pdf-standards.bib`, `billinge-group-bib.bib`, and `{{cookiecutter.repo_name}}.bib`.
+`bg-pdf-standards.bib`, `billinge-group-bib.bib`, and `{{cookiecutter.project_slug}}.bib`.
 `hand-coded.bib` is fore manually added entries.
 The .bib files here are currently empty.


### PR DESCRIPTION
Closes #2 

initial folder structure
![image](https://github.com/user-attachments/assets/73629838-ecd5-47cf-bd71-a5bc7deaa816)


input
```
cookiecutter scikit-package-manuscript/
```
output
![image](https://github.com/user-attachments/assets/07201b19-6785-4d66-b4e1-13ea44ffe8ce)

Final folder structure
![image](https://github.com/user-attachments/assets/12ac3caa-dffd-4884-b088-3c6e4c9020ce)

in the `sb-paper-id`
![image](https://github.com/user-attachments/assets/f5ae225f-1330-4c0d-af9f-fbcb3b9fe964)
