### PR TITLE
fix: enable template selection in all versions of cookiecutter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
   "project_slug": "sb-paper-id",
-  "manuscript_template": ["iucr"]
+  "journal_template": ["iucr"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,4 @@
 {
   "project_slug": "sb-paper-id",
-  "template": ["iucr"]
+  "manuscript_template": ["iucr"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -70,7 +70,7 @@ def load_template(source_dir, target_dir):
 def main():
     sys.path.append(str(Path().cwd().parent))
     target_directory = Path().cwd()
-    copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.manuscript_template }}", target_directory)
+    copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.journal_template }}", target_directory)
     clone_headers(target_directory)
     # template_directory = Path().cwd() / cookiecutter.template
     # load_template(template_directory, target_directory)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -70,7 +70,7 @@ def load_template(source_dir, target_dir):
 def main():
     sys.path.append(str(Path().cwd().parent))
     target_directory = Path().cwd()
-    copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.template }}", target_directory)
+    copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.manuscript_template }}", target_directory)
     clone_headers(target_directory)
     # template_directory = Path().cwd() / cookiecutter.template
     # load_template(template_directory, target_directory)


### PR DESCRIPTION
### What problem does this PR address?
Closes #21 

Enable template selection in the prompts for newer versions of `cookiecutter`.


### What should the reviewer(s) do?
Please check if the fix is acceptable.

Inputs:
```
$ conda install cookiecutter=2.6.0
$ cookiecutter scikit-package-manuscript
```
Outputs:
![image](https://github.com/user-attachments/assets/f16d6aad-14b3-46fc-b83a-5758a39da93e)

`sb-paper-id` is created
![image](https://github.com/user-attachments/assets/a20b165c-92e9-4faf-891f-61576e2651fb)

It also works for `cookiecutter=1.7.3`. The outputs are the same.
