### PR TITLE
feat: fetch latex headers from github repo

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
   "project_slug": "sb-paper-id",
+  "latex_headers_repo": "https://github.com/Billingegroup/latex-headers",
   "journal_template": ["iucr"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -4,6 +4,7 @@ import subprocess
 import tempfile
 from importlib.resources import as_file, files
 import sys
+import re
 
 
 from importlib.resources import files, as_file
@@ -35,45 +36,71 @@ def copy_package_files(package: str, resource_dir: str, target_dir: Path):
                 shutil.copy(item, target_dir / item.name)
 
 
-def clone_headers(target_dir):
-    repo = "https://github.com/Billingegroup/latex-headers"
-    headers = ["packages.tex", "cmds-general.tex", "cmds-programs.tex"]
+def clone_headers(target_dir, repo_url):
     target_path = Path(target_dir)
-
+    package_names = []
+    command_names = []    
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
-        subprocess.run(["git", "clone", repo, str(tmp_path)], check=True)
-        src_dir = tmp_path / "latex_headers"
-        for filename in headers:
-            src = src_dir / filename
-            dst = target_path / filename
-            if not src.is_file():
-                raise FileNotFoundError(f"Missing file: {src}")
-            shutil.copy(src, dst)
+        subprocess.run(["git", "clone", repo_url, str(tmp_path)], check=True)
+        src_dir = tmp_path
+        for item in src_dir.glob('**/*'):
+            if item.is_file() and str(item).endswith(".tex"):
+                item_name = str(item).split('/')[-1]
+                if item_name.startswith('package'):
+                    package_names.append(item_name)
+                elif item_name.startswith('cmd'):
+                    command_names.append(item_name)
+                else:
+                    package_names.append(item_name)
+                shutil.copy(item, target_dir / item_name)
 
-def load_template(source_dir, target_dir):
-    source_path = Path(source_dir)
-    target_path = Path(target_dir)
+    return package_names, command_names
 
-    if not source_path.is_dir():
-        raise NotADirectoryError(f"Source is not a directory: {source_path}")
-    target_path.mkdir(parents=True, exist_ok=True)
-
-    for item in source_path.iterdir():
-        dest = target_path / item.name
-        if item.is_dir():
-            shutil.copytree(item, dest, dirs_exist_ok=True)
+def sort_cmd_headers(command_names):
+    order = []
+    with_order_index = []
+    without_order_index = []
+    for i,name in enumerate(command_names):
+        item_order = re.findall(r'\d+', name)
+        if len(item_order)==0:
+            without_order_index.append(i)
         else:
-            shutil.copy2(item, dest)
+            order.append(int(item_order[0]))
+            with_order_index.append(i)
+
+    order_index = sorted(range(len(order)), key = lambda i: order[i])
+    with_order_index = [with_order_index[i] for i in order_index]
+    sorted_index = [*with_order_index, *without_order_index]
+    command_names = [command_names[i] for i in sorted_index]
+    return command_names
+
+def create_input_files(target_dir, package_names, command_names):
+    target_path = Path(target_dir)
+    package_path = target_path / 'auto-fetch-packages.tex'
+    command_path = target_path / 'auto-fetch-commands.tex'
+
+    with open(package_path, 'w') as f:
+        for name in package_names:
+            f.write(r"\input{" + str(name) + '}')
+            f.write('\n')
+
+    with open(command_path, 'w') as f:
+        for name in command_names:
+            f.write(r"\input{" + str(name) + '}')
+            f.write('\n')
+
 
 
 def main():
     sys.path.append(str(Path().cwd().parent))
     target_directory = Path().cwd()
+
     copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.journal_template }}", target_directory)
-    clone_headers(target_directory)
-    # template_directory = Path().cwd() / cookiecutter.template
-    # load_template(template_directory, target_directory)
+    package_names, command_names = clone_headers(target_directory, "{{ cookiecutter.latex_headers_repo }}")
+    command_names = sort_cmd_headers(command_names)
+
+    create_input_files(target_directory, package_names, command_names)
 
 
 if __name__ == "__main__":

--- a/templates/iucr/manuscript.tex
+++ b/templates/iucr/manuscript.tex
@@ -20,9 +20,8 @@
 % Add extra packages here, e.g.
 % \usepackage{myfavouritepackage}
 % load standard group packages and shortcuts (can be found at billingegroup/latex_headers/ at github.org)
-\input{packages}
-\input{cmds_general}
-\input{cmds_programs}
+\input{auto-fetch-packages}
+\input{auto-fetch-commands}
 % check in cmds\_general.tex how to add your own color/commenting command
 
 \title{Title here

--- a/templates/iucr/supplementary-information.tex
+++ b/templates/iucr/supplementary-information.tex
@@ -1,8 +1,7 @@
 \documentclass{iucrjournals}
 % load standard group packages and shortcuts (can be found at billingegroup/latex_headers/ at github.org)
-\input{packages}
-\input{cmds_general}
-\input{cmds_programs}
+\input{auto-fetch-packages}
+\input{auto-fetch-commands}
 
 \title{Supplementary Information for: \\ \vspace{1cm}
 {{cookiecutter.title}}


### PR DESCRIPTION
### What problem does this PR address?
Closes #12 
Closes #14 

Fetch LaTeX headers from a GitHub repo. 
(1) The default repo URL can be set from `~.skpkgrc` in `latex_headers_repo`.
(2) All files ending with `.tex` in the repo will be fetched at the same level in the manuscript.
(3) `.tex` files that start with `cmd` will be recognized as command files.
(4) `.tex` files that start with `package` and the other prefixes will be recognized as package files.
(5) Command files will be sorted according to the first several numbers in their names. Files without a number in their names will be put at the end.

### What should the reviewer(s) do?
Please check the inputs and outputs.

(1) Default
Inputs:
```
cookiecutter scikit-package-manuscript
```
Outputs:

![image](https://github.com/user-attachments/assets/87a0c11b-ea8f-4ef7-960c-124a45f768a9)

```
$ tree sb-paper-id -L 1
sb-paper-id/
├── auto-fetch-commands.tex
├── auto-fetch-packages.tex
├── cmds-general.tex
├── cmds-programs.tex
├── packages.tex
├── ...

$ cat sb-paper-id/auto-fetch-commands.tex 
\input{cmds-programs.tex}
\input{cmds-general.tex}

$ cat sb-paper-id/auto-fetch-packages.tex 
\input{packages.tex}
```

(2) With  `~/.skpkgrc`
```
{
"default_context":
   {
  "latex_headers_repo": "https://github.com/ycexiao/test-headers.git"
  }
}
```
The `test-headers` repo
```
├── folder1
│   ├── cmds-1.tex
│   ├── cmds-2.tex
│   ├── folder3
│   │   └── packages-math.tex
│   └── not_a_tex
├── folder2
│   └── packages.tex
└── pac1.tex
```

Inputs:
```
cookiecutter scikit-package-manuscript --config-file ~/.skpkgrc  # equivalent to `spm` after it is merged
```
Outputs:
```
$ tree sb-paper-id/ -L 1
sb-paper-id/
├── auto-fetch-commands.tex
├── auto-fetch-packages.tex
├── cmds-1.tex
├── cmds-2.tex
├── pac1.tex
├── packages-math.tex
├── packages.tex
└── ...

$ cat sb-paper-id/auto-fetch-commands.tex 
\input{cmds-1.tex}
\input{cmds-2.tex}

$ cat sb-paper-id/auto-fetch-packages.tex 
\input{pac1.tex}
\input{packages.tex}
\input{packages-math.tex}
```
