### PR TITLE
fix: incorrect copy path in `package create manuscript`

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -10,29 +10,32 @@ from importlib.resources import files, as_file
 from pathlib import Path
 import shutil
 
-def copy_package_files(package: str, resource_dir: str, target_dir: Path):
+def copy_package_files(resource_dir: str, target_dir: Path):
     """
     Copies all files from a package's internal resource directory to a target directory.
 
     Args:
-        package (str): Dotted path to the package (e.g., "mypackage.resources").
         resource_dir (str): Subdirectory inside the package (relative to package root).
         target_dir (Path): Filesystem path to copy files to.
     """
+    repo = "https://github.com/scikit-package/scikit-package-manuscript.git"
     target_dir = Path(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
 
     # Get the directory of resources
-    resource_root = files(package) / resource_dir
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        subprocess.run(["git", "clone", repo, str(tmp)], check=True)
+        resource_dir = tmp_path / "templates" /resource_dir
 
-    # Use as_file to ensure we get a real path (even if inside a zip)
-    with as_file(resource_root) as root_path:
-        if not root_path.is_dir():
-            raise NotADirectoryError(f"{resource_root} is not a directory")
+        # Use as_file to ensure we get a real path (even if inside a zip)
+        with as_file(resource_dir) as root_path:
+            if not root_path.is_dir():
+                raise NotADirectoryError(f"{resource_root} is not a directory")
 
-        for item in root_path.iterdir():
-            if item.is_file():
-                shutil.copy(item, target_dir / item.name)
+            for item in root_path.iterdir():
+                if item.is_file():
+                    shutil.copy(item, target_dir / item.name)
 
 
 def clone_headers(target_dir):
@@ -70,7 +73,7 @@ def load_template(source_dir, target_dir):
 def main():
     sys.path.append(str(Path().cwd().parent))
     target_directory = Path().cwd()
-    copy_package_files("scikit-package-manuscript.templates", "{{ cookiecutter.journal_template }}", target_directory)
+    copy_package_files("{{ cookiecutter.journal_template }}", target_directory)
     clone_headers(target_directory)
     # template_directory = Path().cwd() / cookiecutter.template
     # load_template(template_directory, target_directory)


### PR DESCRIPTION
### What problem does this PR address?

Closes #29 

### What should the reviewer(s) do?

Please check my fix. The bug is caused by copying package files based on the path of the cloned `scikit-package-manuscript` folder. It works only when there is a `scikit-package-manuscript` subfolder in the current directory.
```
git clone <scikit-pacakge-manuscript>
cookiecutter scikit-package-manuscript   
package create manuscript
```

The solution in the PR is to clone the `scikit-package-manuscript` repo in the `post-hook`. It  can be tested by 
```
cookiecutter https://github.com/ycexiao/scikit-package-manuscript.git
```
Output:
![image](https://github.com/user-attachments/assets/4db605fa-6def-44cd-9a04-43f76f2717ac)

```
sb-paper-id/
├── manuscript.tex
├── ...
```
