### PR TITLE
feat: set a new default source for fetching headers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
   "project_slug": "sb-paper-id",
   "journal_template": ["iucr"],
-  "latex_headers_repo": "https://github.com/Billingegroup/latex-headers"
+  "latex_headers_repo": "https://github.com/scikit-package/default-latex-headers.git"
 }


### PR DESCRIPTION
### What problem does this PR address
Closes #34 

The default headers to be included in users' manuscripts are now defined in https://github.com/scikit-package/default-latex-headers#

### What should the reviewers do

(1) **The default behavior without `~/.cookiecutterrc`**
Inputs:
```
cookiecutter scikit-package-manuscript
```
Outputs:
![image](https://github.com/user-attachments/assets/b3001d48-e036-498e-be53-43dd6ce613d0)

There are no .tex files in `default-latex-headers` currently, so the input region is empty

![image](https://github.com/user-attachments/assets/18857c9d-7a73-414e-af8c-b56f7e208d4e)

(2) **If user provide `latex_headers_repo` in `~/.cookiecutterrc`,  which will be equivalent to `~/.skpkgrc` after this PR is merged**:
```
{
  "default_context":
  {
  "latex_headers_repo": "https://github.com/Billingegroup/latex-headers"
  }
}

```

Outputs:
![image](https://github.com/user-attachments/assets/25e5e320-f15a-459d-ba49-b9b7d73db9ad)
![image](https://github.com/user-attachments/assets/7435a81c-754e-4d9d-a3bb-0121bb91b112)
