### PR TITLE
refactor: redo the post_gen_project.py implementation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,129 +1,41 @@
-import shutil
-import subprocess
-import tempfile
-from pathlib import Path
-
-MANUSCRIPT_FILENAME = "manuscript.tex"
+def get_input_type():
+    pass
 
 
-def get_scikit_manuscript_dir():
-    """Return the full path to the local scikit-package-manuscript
-    dir."""
-    cookiecutter_dir = Path.home() / ".cookiecutters"
-    candidates = []
-    for candidate in cookiecutter_dir.iterdir():
-        candidates.append(candidate)
-        if (candidate.is_dir() and
-                "scikit-package-manuscript" in candidate.name):
-            return candidate.resolve()
-    return Path(f"couldn't find scikit-package-manuscript, but did "
-                f"find {*candidates,}")  # noqa E231
+def copy_files_from_url():
+    pass
 
 
-def copy_journal_template_files(journal_template_name, project_dir):
-    """Copies files from a package's resource directory to a target
-    directory.
-
-    Parameters:
-    ===========
-    journal_template : str
-      The name of the journal latex template to use, e.g. 'article'.
-      It must be one of the available templates.
-    project_dir : Path
-      The path to the location of the output project where the files
-      will be copied to.
-    """
-    cookiecutter_path = get_scikit_manuscript_dir()
-    template_dir = cookiecutter_path / "templates" / journal_template_name
-    if not template_dir.exists():
-        raise FileNotFoundError(f"Cannot find the provided journal_template: "
-                                f"{journal_template_name}. Please contact the "
-                                f"software developers.")
-
-    if not any(template_dir.iterdir()):
-        raise FileNotFoundError(f"Template {journal_template_name} found but "
-                                f"it contains no files. Please contact the "
-                                f"software developers.")
-    for item in template_dir.iterdir():
-        dest = project_dir / item.name
-        if item.is_dir():
-            shutil.copytree(item, dest, dirs_exist_ok=True)
-        else:
-            shutil.copy2(item, dest)
-    return
+def copy_files_from_local():
+    pass
 
 
-def get_user_headers(repo_url):
-    """Clone a Git repository containing LaTeX header files into a
-    string."""
-    headers = ""
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        subprocess.run(["git", "clone", repo_url, str(tmp_path)], check=True)
-        for item in tmp_path.glob('**/*'):
-            if item.is_file() and str(item).endswith(".tex"):
-                headers += item.read_text()+'\n'
-    return headers
+def get_file_type():
+    pass
 
 
-def extract_manuscript_packages(manuscript_path):
-    contents = manuscript_path.read_text(encoding="utf-8")
-    packages, the_rest = split_usepackage_lines(contents)
-    Path(manuscript_path).write_text(the_rest, encoding="utf-8")
-    return packages
+def extract_lines():
+    pass
 
 
-def split_usepackage_lines(headers):
-    usepackage_lines = []
-    other_lines = []
-    for line in headers.splitlines():
-        if line.lstrip().startswith(r"\usepackage"):
-            usepackage_lines.append(line)
-        else:
-            other_lines.append(line)
-    return "\n".join(usepackage_lines), "\n".join(other_lines)
+def insert_lines():
+    pass
 
 
-def insert_below_documentclass(manuscript_text, insert_text):
-    lines = manuscript_text.splitlines()
-    result_lines = []
-    inserted = False
-    for line in lines:
-        result_lines.append(line)
-        if not inserted and r"\documentclass" in line:
-            result_lines.append(insert_text)
-            inserted = True
-    return "\n".join(result_lines)
+def copy_journal_template():
+    pass
 
 
-def recompose_manuscript(manuscript_path, user_packages, user_commands):
-    new_header = "\n".join([user_packages, user_commands])
-    manuscript_contents = manuscript_path.read_text(encoding="utf-8")
-    manuscript_contents_with_header = insert_below_documentclass(
-        manuscript_contents, new_header
-    )
-    manuscript_path.write_text(
-        manuscript_contents_with_header, encoding="utf-8"
-    )
+def add_headers_to_manuscript():
+    pass
+
+
+def add_bibliography_to_manuscript():
+    pass
 
 
 def main():
-    project_dir = Path().cwd()
-    manuscript_path = project_dir / MANUSCRIPT_FILENAME
-    if ("{{ cookiecutter.latex_headers_repo_url }}" ==
-            "use-scikit-package-default"):
-        user_headers_repo_url = \
-            "https://github.com/scikit-package/default-latex-headers.git"
-    else:
-        user_headers_repo_url = "{{ cookiecutter.latex_headers_repo_url }}"
-    copy_journal_template_files(
-        "{{ cookiecutter.journal_template }}", project_dir
-    )
-    user_headers = get_user_headers(user_headers_repo_url)
-    manuscript_packages = extract_manuscript_packages(manuscript_path)
-    user_packages, the_rest = split_usepackage_lines(user_headers)
-    all_packages = "\n".join([manuscript_packages, user_packages])
-    recompose_manuscript(manuscript_path, all_packages, the_rest)
+    pass
 
 
 if __name__ == "__main__":

--- a/hooks/test_post_gen_project.py
+++ b/hooks/test_post_gen_project.py
@@ -1,50 +1,59 @@
-from pathlib import Path
-
-import pytest
-from post_gen_project import copy_journal_template_files
-
-
-# C1: multiple files in the template, expect all files will be copied
-#   to project_path
-def test_copy_journal_template_files(
-    user_filesystem, template_files, mock_home
-):
-    project_dir = Path(user_filesystem / "project-dir")
-    project_dir.mkdir(parents=True, exist_ok=True)
-    copy_journal_template_files("article", project_dir)
-    for key, value in template_files.items():
-        assert Path(project_dir / key).exists()
-        assert Path(project_dir / key).read_text() == value
+# C1: a repo url. Expect return "url"
+# C2: a local path. Expect return "local".
+# C3: None. Expect return "None".
+def test_get_input_type():
+    pass
 
 
-@pytest.mark.parametrize(
-    "input,errormessage",
-    [
-        # C1: template exists no files in the template. Expect
-        # FileNotFoundError
-        (
-            "other",
-            "Template other found but it contains no "
-            "files. Please contact the software "
-            "developers.",
-        ),
-        # C2: desired template does not exist. Expect FileNotFoundError
-        (
-            "yet-another",
-            "Cannot find the provided journal_template: "
-            "yet-another. Please contact the "
-            "software developers.",
-        ),
-    ],
-)
-def test_copy_journal_template_files_bad(
-    user_filesystem, mock_home, input, errormessage
-):
-    project_dir = Path(user_filesystem / "project-dir")
-    project_dir.mkdir(parents=True, exist_ok=True)
+# C1: a repo url.
+#   Expect all files are copied and all copied files name are returned.
+def test_copy_files_from_url():
+    pass
 
-    with pytest.raises(
-        FileNotFoundError,
-        match=errormessage,
-    ):
-        copy_journal_template_files(input, project_dir)
+
+# C1: an not existing url. Expect FileNotFoundError.
+def test_copy_files_from_url_bad():
+    pass
+
+
+# C1: a directory path.
+#   Expect all files are copied and all copied files name are returned.
+def test_copy_files_from_local():
+    pass
+
+
+# C1: a not existing directory path. Expect return FileNotFoundError.
+def test_copy_files_from_local_bad():
+    pass
+
+
+# C1: a header file. Expect return "header"
+# C2: a bib file. Expect return "bib"
+# C3: another file. Expect return "other"
+def test_get_file_type():
+    pass
+
+
+# C1: a keyword like "usepackage" and the content.
+#   Expect all lines containing the keyword and other content are returned.
+def test_extract_lines():
+    pass
+
+
+# C1: lines to be inserted, content,
+#   location keyword like "begin{document}" and method "below" or "above".
+#   Expect lines are inserted into the content "below" or "above"
+#   the first line containing the keyword.
+def test_insert_lines():
+    pass
+
+
+# C1: a existing template name.
+#   Expect all files in the template are copied to the project_dir
+def test_copy_journal_template():
+    pass
+
+
+# C1: a non existing template name. Expect FileNotFoundError.
+def test_copy_journal_template_bad():
+    pass


### PR DESCRIPTION
Redo the `scikit-package-manuscript` implementation. Follow the flow from behavior, to design, to testing, and then to code