### PR TITLE
fix: allow workflow write permission

### DIFF
--- a/.github/workflows/build-wheel-release-upload.yml
+++ b/.github/workflows/build-wheel-release-upload.yml
@@ -16,5 +16,3 @@ jobs:
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-    permissions:
-      contents: read


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Please attach outputs, including screenshots (before/after), if they help the reviewer. -->

Fix the release bugs reported in Slack.

### What should the reviewer(s) do?

The workflow went wrong: https://github.com/scikit-package/scikit-package-manuscript/actions/runs/20433602189/job/58709660157

The cause:
<img width="1068" height="521" alt="image" src="https://github.com/user-attachments/assets/4d0bab16-c56c-49d0-b09f-2abc0a983204" />
`GITHUB_TOKEN` only has `read` permission.

What expected:
<img width="693" height="771" alt="image" src="https://github.com/user-attachments/assets/d994ca9d-e573-4f22-8c55-1ff9307cdba8" />
(taken from a successful workflow in another scikit-package repo)

If the workflow has write permission in settings, it might be caused by `Rules` or `yml` file.

`yml` file in other repos doesn't have
```
    permissions:
      contents: read
```

Try to remove the two lines to see if it works.
